### PR TITLE
Add subtitle data layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,16 +27,35 @@ OUTPUT_DIR=./youtube-clips
 MAX_VIDEO_HEIGHT=1080
 
 # ============================================================================
-# 字幕翻译配置
+# 字幕翻译配置（旧版 Skill 编排）
 # ============================================================================
 
-# 批量翻译大小（每批翻译的字幕条数）
-# 推荐: 20-25
-TRANSLATION_BATCH_SIZE=20
+# 批量翻译大小由下方 V2 配置块中的 TRANSLATION_BATCH_SIZE 统一定义
 
 # 目标翻译语言
 # 选项: 中文, 日语, 韩语, 西班牙语, 等
 TARGET_LANGUAGE=中文
+
+# ============================================================================
+# 字幕翻译 V2 配置（B1-lite / OpenAI-compatible / CPA）
+# ============================================================================
+
+TRANSLATION_PROVIDER=openai-compatible
+TRANSLATION_BASE_URL=http://127.0.0.1:8317/v1
+TRANSLATION_API_KEY=
+TRANSLATION_MODEL=deepseek-chat
+TRANSLATION_REVIEW_MODEL=
+TRANSLATION_TARGET_LANG=zh-CN
+TRANSLATION_MODE=balanced
+TRANSLATION_BATCH_SIZE=80
+TRANSLATION_CONTEXT_BEFORE=10
+TRANSLATION_CONTEXT_AFTER=10
+TRANSLATION_TEMPERATURE=0.1
+TRANSLATION_MAX_RETRIES=3
+TRANSLATION_CACHE=true
+TRANSLATION_CACHE_PATH=.translation_cache.sqlite3
+TRANSLATION_GLOSSARY_PATH=glossary.md
+TRANSLATION_QA=suspicious-only
 
 # ============================================================================
 # 章节分析配置

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ build/
 .env
 .env.local
 .env.*.local
+.translation_cache*
+
+# Local agent state
+.omc/
 
 # IDE
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+This repository is a Claude Code skill for clipping long-form videos into short segments. The main workflow is defined in `SKILL.md`: environment check, video download, subtitle analysis, chapter selection, clip processing, and output packaging.
+
+## Common commands
+
+Run commands from repository root: `E:/MySecondBrain/Vault/dev-workspace/projects/automation/cli/youtube-clipper-skill`.
+
+### Environment setup
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### Toolchain verification
+
+```powershell
+yt-dlp --version
+ffmpeg -version
+ffmpeg -filters | Select-String subtitles
+python -c "import yt_dlp, pysrt, dotenv; print('deps ok')"
+```
+
+### Config
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Important runtime settings live in `.env`, including clip pipeline settings plus translation V2 keys like `TRANSLATION_BASE_URL`, `TRANSLATION_API_KEY`, `TRANSLATION_MODEL`, `TRANSLATION_TARGET_LANG`, `TRANSLATION_QA`, and `TRANSLATION_CACHE_PATH`.
+
+### Script entrypoints
+
+```powershell
+python scripts/download_video.py <youtube_url>
+python scripts/analyze_subtitles.py <subtitle_path>
+python scripts/clip_video.py <video_path> <start_time> <end_time> <output_path>
+python scripts/translate_subtitles.py <subtitle_path>
+python scripts/translate_subtitles_v2.py <subtitle_path> [options]
+python scripts/burn_subtitles.py <video_path> <subtitle_path> <output_path>
+python scripts/generate_summary.py <chapter_info>
+```
+
+### Installation as Claude skill
+
+`install_as_skill.sh` is a bash script. On Windows, run it from Git Bash or WSL instead of plain PowerShell.
+
+```bash
+bash install_as_skill.sh
+```
+
+This installs repository into `~/.claude/skills/youtube-clipper/` for end-user skill usage.
+
+## Architecture
+
+### Control plane
+
+- `SKILL.md` is source of truth for end-to-end user workflow and expected agent behavior.
+- `README.md` documents installation, configuration, and output layout.
+- `install_as_skill.sh` packages repo into Claude skill directory and performs dependency checks.
+
+### Processing pipeline
+
+All implementation code lives under `scripts/`.
+
+- `download_video.py` downloads source video and subtitles with `yt-dlp`.
+- `analyze_subtitles.py` parses VTT subtitles and prepares structured data for Claude chapter analysis.
+- `clip_video.py` extracts video segments with FFmpeg.
+- `extract_subtitle_clip.py` trims subtitle ranges to clip boundaries.
+- `translate_subtitles.py` batches subtitle translation and can produce bilingual subtitle data.
+- `merge_bilingual_subtitles.py` combines original and translated subtitles.
+- `burn_subtitles.py` burns subtitles into video and handles FFmpeg/libass detection.
+- `generate_summary.py` creates shareable summary copy for clips.
+- `utils.py` holds shared helpers for time conversion, filename sanitization, path creation, and formatting.
+
+### External dependencies
+
+- `yt-dlp` handles video and subtitle acquisition.
+- `ffmpeg` handles clip extraction and subtitle burn-in.
+- `libass` support is required for subtitle burning.
+- `pysrt` handles SRT parsing and writing.
+- `python-dotenv` loads `.env` configuration.
+
+## Repo-specific notes
+
+- Repository now has focused unittest coverage for translation V2 config and CLI behavior. Other script changes still need smoke checks and dependency verification.
+- Subtitle burning depends on FFmpeg subtitle filter support. If `ffmpeg -filters` does not show `subtitles`, hard-subtitle flow is broken.
+- This repo is designed first as script-backed skill, not long-running service or web app. Keep changes aligned with CLI/script workflow.
+- Output defaults to `./youtube-clips/<timestamp>/...` unless overridden in `.env`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yt-dlp>=2024.01.01
+pysrt>=1.1.2
+python-dotenv>=1.0.0

--- a/scripts/translate_subtitles_v2.py
+++ b/scripts/translate_subtitles_v2.py
@@ -80,6 +80,10 @@ def _print_report_summary(result: PipelineResult, safe_config: dict[str, object]
     print(f"input_format: {result.input_format}")
     print(f"output_format: {result.output_format}")
     print(f"cue_count: {result.cue_count}")
+    if result.first_cue_preview is not None:
+        print(f"first_cue_preview: {result.first_cue_preview}")
+    if result.last_cue_preview is not None:
+        print(f"last_cue_preview: {result.last_cue_preview}")
     print("config:")
     for key, value in safe_config.items():
         print(f"  {key}: {value}")

--- a/scripts/translate_subtitles_v2.py
+++ b/scripts/translate_subtitles_v2.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from translation.config import load_config
+from translation.models import PipelineResult
+from translation.pipeline import run_translation_pipeline
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Translate subtitles with B1-lite config/CLI pipeline.")
+    parser.add_argument("subtitle_path", help="Input subtitle file (.srt or .vtt)")
+    parser.add_argument("--env-file", default=".env", help="Path to .env file")
+    parser.add_argument("--output-dir", help="Output directory; defaults to <subtitle_dir>/translated")
+    parser.add_argument("--target-lang", dest="target_lang", help="Target language, e.g. zh-CN")
+    parser.add_argument("--model", help="Translation model name")
+    parser.add_argument("--review-model", dest="review_model", help="QA/review model name")
+    parser.add_argument("--base-url", dest="base_url", help="OpenAI-compatible base URL")
+    parser.add_argument("--glossary", dest="glossary_path", help="Glossary markdown path")
+    parser.add_argument("--batch-size", dest="batch_size", type=int, help="Cue count per batch")
+    parser.add_argument("--context-before", dest="context_before", type=int, help="Reference cue count before batch")
+    parser.add_argument("--context-after", dest="context_after", type=int, help="Reference cue count after batch")
+    parser.add_argument("--temperature", type=float, help="Model temperature")
+    parser.add_argument("--max-retries", dest="max_retries", type=int, help="Maximum retries per batch")
+    parser.add_argument("--cache-path", dest="cache_path", help="SQLite cache path")
+    parser.add_argument("--qa", dest="qa_mode", choices=["suspicious-only", "none"], help="QA mode")
+    parser.add_argument("--no-cache", dest="cache_enabled", action="store_false", default=None, help="Disable cache")
+    parser.add_argument("--no-qa", dest="qa_mode", action="store_const", const="none", help="Disable QA")
+    parser.add_argument("--dry-run", action="store_true", help="Print resolved config and output paths only")
+    parser.add_argument("--overwrite", action="store_true", help="Allow replacing existing outputs")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cli_args = _namespace_to_config_args(args)
+
+    try:
+        config = load_config(cli_args=cli_args, env_path=args.env_file)
+        result = run_translation_pipeline(args.subtitle_path, config)
+    except (FileExistsError, FileNotFoundError, NotImplementedError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    _print_report_summary(result, config.to_safe_dict())
+    return 0
+
+
+def _namespace_to_config_args(args: argparse.Namespace) -> dict[str, object]:
+    return {
+        "base_url": args.base_url,
+        "model": args.model,
+        "review_model": args.review_model,
+        "target_lang": args.target_lang,
+        "batch_size": args.batch_size,
+        "context_before": args.context_before,
+        "context_after": args.context_after,
+        "temperature": args.temperature,
+        "max_retries": args.max_retries,
+        "cache_enabled": args.cache_enabled,
+        "cache_path": args.cache_path,
+        "glossary_path": args.glossary_path,
+        "qa_mode": args.qa_mode,
+        "output_dir": args.output_dir,
+        "dry_run": args.dry_run,
+        "overwrite": args.overwrite,
+    }
+
+
+def _print_report_summary(result: PipelineResult, safe_config: dict[str, object]) -> None:
+    print("Dry run" if result.dry_run else "Translation run")
+    print(f"input_path: {result.input_path}")
+    print(f"input_format: {result.input_format}")
+    print(f"output_format: {result.output_format}")
+    print(f"cue_count: {result.cue_count}")
+    print("config:")
+    for key, value in safe_config.items():
+        print(f"  {key}: {value}")
+    print("outputs:")
+    print(f"  translated_srt: {result.output_paths.translated_srt}")
+    print(f"  bilingual_srt: {result.output_paths.bilingual_srt}")
+    print(f"  translation_report: {result.output_paths.translation_report}")
+    print(f"  global_context: {result.output_paths.global_context}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/subtitles_cases.py
+++ b/tests/subtitles_cases.py
@@ -1,0 +1,223 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from translation.models import Cue
+from translation.subtitles import (
+    detect_subtitle_format,
+    parse_srt,
+    parse_subtitle_file,
+    parse_vtt,
+    validate_cues,
+    validate_translations,
+    write_bilingual_srt,
+    write_translated_srt,
+)
+
+
+class SubtitleParserTests(unittest.TestCase):
+    def test_detect_subtitle_format_accepts_srt_and_vtt_only(self):
+        self.assertEqual(detect_subtitle_format(Path("sample.srt")), "srt")
+        self.assertEqual(detect_subtitle_format(Path("sample.vtt")), "vtt")
+
+        with self.assertRaisesRegex(ValueError, "subtitle_path must point to .srt or .vtt"):
+            detect_subtitle_format(Path("sample.ass"))
+
+    def test_parse_subtitle_file_reads_utf8_sig_and_validates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "﻿1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+
+            cues = parse_subtitle_file(subtitle_path)
+
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_parse_ordinary_srt(self):
+        cues = parse_srt("1\n00:00:00,000 --> 00:00:01,000\nhello\n\n")
+
+        self.assertEqual(
+            cues,
+            [
+                Cue(
+                    id="1",
+                    index=1,
+                    start="00:00:00,000",
+                    end="00:00:01,000",
+                    source="hello",
+                    raw_timing="00:00:00,000 --> 00:00:01,000",
+                )
+            ],
+        )
+
+    def test_parse_multiline_srt_source(self):
+        cues = parse_srt("1\n00:00:00,000 --> 00:00:01,000\nhello\nworld\n\n")
+
+        self.assertEqual(cues[0].source, "hello\nworld")
+
+    def test_parse_srt_without_trailing_blank_line(self):
+        cues = parse_srt("1\n00:00:00,000 --> 00:00:01,000\nhello")
+
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_parse_srt_with_crlf_newlines(self):
+        cues = parse_srt("1\r\n00:00:00,000 --> 00:00:01,000\r\nhello\r\n\r\n")
+
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_parse_srt_keeps_digit_only_source_line(self):
+        cues = parse_srt(
+            "1\n"
+            "00:00:00,000 --> 00:00:01,000\n"
+            "42\n"
+            "meaning\n\n"
+            "2\n"
+            "00:00:02,000 --> 00:00:03,000\n"
+            "done\n"
+        )
+
+        self.assertEqual(len(cues), 2)
+        self.assertEqual(cues[0].source, "42\nmeaning")
+
+    def test_parse_srt_without_sequence_uses_internal_index_as_id(self):
+        cues = parse_srt("00:00:00,000 --> 00:00:01,000\nhello\n\n")
+
+        self.assertEqual(cues[0].id, "1")
+        self.assertEqual(cues[0].index, 1)
+
+    def test_parse_srt_non_numeric_identifier_line_uses_internal_index(self):
+        cues = parse_srt("subtitle-abc\n00:00:00,000 --> 00:00:01,000\nhello\n\n")
+
+        self.assertEqual(cues[0].id, "1")
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_parse_empty_srt_raises_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "subtitle file contains no cues"):
+            parse_srt("")
+
+    def test_parse_srt_with_empty_source_raises_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "source is empty"):
+            parse_srt("1\n00:00:00,000 --> 00:00:01,000\n\n")
+
+    def test_parse_vtt_with_header_and_ordinary_cue(self):
+        cues = parse_vtt("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n\n")
+
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].id, "1")
+        self.assertEqual(cues[0].start, "00:00:00,000")
+        self.assertEqual(cues[0].end, "00:00:01,000")
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_parse_vtt_with_cue_identifier(self):
+        cues = parse_vtt("WEBVTT\n\nintro-cue\n00:00:00.000 --> 00:00:01.000\nhello\n\n")
+
+        self.assertEqual(cues[0].id, "intro-cue")
+
+    def test_parse_vtt_with_timing_settings(self):
+        cues = parse_vtt(
+            "WEBVTT\n\n"
+            "00:00:00.000 --> 00:00:01.000 align:start position:0%\n"
+            "hello\n\n"
+        )
+
+        self.assertEqual(cues[0].raw_timing, "00:00:00.000 --> 00:00:01.000 align:start position:0%")
+        self.assertEqual(cues[0].start, "00:00:00,000")
+        self.assertEqual(cues[0].end, "00:00:01,000")
+
+    def test_parse_vtt_skips_note_style_and_region_blocks(self):
+        cues = parse_vtt(
+            "WEBVTT\n\n"
+            "NOTE this is metadata\nignored\n\n"
+            "STYLE\n::cue { color: white }\n\n"
+            "REGION\nid:fred\n\n"
+            "00:00:00.000 --> 00:00:01.000\nhello\n\n"
+        )
+
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].source, "hello")
+
+    def test_validate_cues_rejects_duplicate_ids(self):
+        cues = [
+            Cue(id="same", index=1, start="00:00:00,000", end="00:00:01,000", source="a"),
+            Cue(id="same", index=2, start="00:00:02,000", end="00:00:03,000", source="b"),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "duplicate cue id: same"):
+            validate_cues(cues)
+
+    def test_validate_cues_rejects_missing_fields(self):
+        cues = [Cue(id="1", index=1, start="00:00:00,000", end="", source="hello")]
+
+        with self.assertRaisesRegex(ValueError, "cue id 1 end is empty"):
+            validate_cues(cues)
+
+    def test_validate_cues_rejects_non_contiguous_indexes(self):
+        cues = [Cue(id="1", index=2, start="00:00:00,000", end="00:00:01,000", source="hello")]
+
+        with self.assertRaisesRegex(ValueError, "cue index must be 1, got 2"):
+            validate_cues(cues)
+
+
+class SubtitleWriterTests(unittest.TestCase):
+    def setUp(self):
+        self.cues = [
+            Cue(id="intro", index=1, start="00:00:00,000", end="00:00:01,000", source="hello"),
+            Cue(id="2", index=2, start="00:00:02,000", end="00:00:03,000", source="world"),
+        ]
+        self.translations = {"intro": "你好", "2": "世界"}
+
+    def test_validate_translations_requires_same_count(self):
+        with self.assertRaisesRegex(ValueError, "translation count 1 does not match cue count 2"):
+            validate_translations(self.cues, {"intro": "你好"})
+
+    def test_validate_translations_reports_missing_cue_id(self):
+        with self.assertRaisesRegex(ValueError, "missing translation for cue id 2"):
+            validate_translations(self.cues, {"intro": "你好", "other": "别的"})
+
+    def test_validate_translations_reports_blank_translation(self):
+        with self.assertRaisesRegex(ValueError, "translation for cue id intro is empty"):
+            validate_translations(self.cues, {"intro": "  ", "2": "世界"})
+
+    def test_write_translated_srt_writes_only_translation_text(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "nested" / "translated.srt"
+
+            write_translated_srt(self.cues, self.translations, output_path)
+
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            content,
+            "1\n00:00:00,000 --> 00:00:01,000\n你好\n\n"
+            "2\n00:00:02,000 --> 00:00:03,000\n世界\n\n",
+        )
+
+    def test_write_bilingual_srt_defaults_translation_before_source(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "bilingual.srt"
+
+            write_bilingual_srt(self.cues, self.translations, output_path)
+
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("你好\nhello", content)
+        self.assertIn("世界\nworld", content)
+
+    def test_write_bilingual_srt_can_write_source_before_translation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "bilingual.srt"
+
+            write_bilingual_srt(self.cues, self.translations, output_path, source_first=True)
+
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("hello\n你好", content)
+        self.assertIn("world\n世界", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/translate_subtitles_v2_cli_cases.py
+++ b/tests/translate_subtitles_v2_cli_cases.py
@@ -145,6 +145,46 @@ class TranslateSubtitlesV2CliTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("overwrite: True", result.stdout)
 
+    def test_vtt_dry_run_reports_vtt_input_and_srt_output(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.vtt"
+            subtitle_path.write_text(
+                "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(subtitle_path), "--dry-run"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("input_format: vtt", result.stdout)
+        self.assertIn("output_format: srt", result.stdout)
+        self.assertIn("cue_count: 1", result.stdout)
+
+    def test_non_dry_run_fails_with_clear_unimplemented_message(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(subtitle_path)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Translation provider execution is not implemented", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/translate_subtitles_v2_cli_cases.py
+++ b/tests/translate_subtitles_v2_cli_cases.py
@@ -1,0 +1,150 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "translate_subtitles_v2.py"
+
+
+class TranslateSubtitlesV2CliTests(unittest.TestCase):
+    def test_help_displays_expected_arguments(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("subtitle_path", result.stdout)
+        self.assertIn("--output-dir", result.stdout)
+        self.assertIn("--dry-run", result.stdout)
+        self.assertIn("--no-cache", result.stdout)
+        self.assertIn("--no-qa", result.stdout)
+        self.assertNotIn("--api-key", result.stdout)
+
+    def test_missing_subtitle_path_returns_usage_error(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("subtitle_path", result.stderr)
+
+    def test_dry_run_prints_safe_config_and_does_not_write_secret(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+            env_path = Path(temp_dir) / ".env"
+            env_path.write_text(
+                "TRANSLATION_API_KEY=env-secret\nTRANSLATION_MODEL=env-model\n",
+                encoding="utf-8",
+            )
+            output_dir = Path(temp_dir) / "out"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(subtitle_path),
+                    "--env-file",
+                    str(env_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--model",
+                    "cli-model",
+                    "--target-lang",
+                    "zh-CN",
+                    "--no-cache",
+                    "--no-qa",
+                    "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Dry run", result.stdout)
+        self.assertIn("cli-model", result.stdout)
+        self.assertIn("cache_enabled: False", result.stdout)
+        self.assertIn("qa_mode: none", result.stdout)
+        self.assertIn("translated.zh-CN.srt", result.stdout)
+        self.assertNotIn("env-secret", result.stdout)
+        self.assertNotIn("TRANSLATION_API_KEY", result.stdout)
+
+    def test_existing_outputs_require_overwrite(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+            output_dir = Path(temp_dir) / "out"
+            output_dir.mkdir()
+            (output_dir / "translated.zh-CN.srt").write_text("existing", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(subtitle_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already exists", result.stderr)
+        self.assertIn("--overwrite", result.stderr)
+
+    def test_overwrite_allows_dry_run_when_output_exists(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+            output_dir = Path(temp_dir) / "out"
+            output_dir.mkdir()
+            (output_dir / "translated.zh-CN.srt").write_text("existing", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(subtitle_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--dry-run",
+                    "--overwrite",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("overwrite: True", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/translation_config_cases.py
+++ b/tests/translation_config_cases.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from translation.config import TranslationConfig, load_config
+from translation.pipeline import run_translation_pipeline
+
+
+class TranslationConfigTests(unittest.TestCase):
+    def test_env_values_load_and_cli_overrides_take_precedence(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        "TRANSLATION_PROVIDER=openai-compatible",
+                        "TRANSLATION_BASE_URL=http://env.example/v1",
+                        "TRANSLATION_API_KEY=env-secret",
+                        "TRANSLATION_MODEL=env-model",
+                        "TRANSLATION_TARGET_LANG=ja-JP",
+                        "TRANSLATION_BATCH_SIZE=42",
+                        "TRANSLATION_CONTEXT_BEFORE=4",
+                        "TRANSLATION_CONTEXT_AFTER=5",
+                        "TRANSLATION_TEMPERATURE=0.7",
+                        "TRANSLATION_MAX_RETRIES=2",
+                        "TRANSLATION_CACHE=false",
+                        "TRANSLATION_CACHE_PATH=env-cache.sqlite3",
+                        "TRANSLATION_GLOSSARY_PATH=env-glossary.md",
+                        "TRANSLATION_QA=suspicious-only",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            config = load_config(
+                cli_args={
+                    "model": "cli-model",
+                    "target_lang": "zh-CN",
+                    "batch_size": 80,
+                    "cache_enabled": True,
+                    "qa_mode": "none",
+                },
+                env_path=env_path,
+                environ={},
+            )
+
+        self.assertEqual(config.base_url, "http://env.example/v1")
+        self.assertEqual(config.api_key, "env-secret")
+        self.assertEqual(config.model, "cli-model")
+        self.assertEqual(config.review_model, None)
+        self.assertEqual(config.effective_review_model, "cli-model")
+        self.assertEqual(config.target_lang, "zh-CN")
+        self.assertEqual(config.batch_size, 80)
+        self.assertTrue(config.cache_enabled)
+        self.assertEqual(config.qa_mode, "none")
+
+    def test_unsupported_provider_raises_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "only openai-compatible is supported"):
+            TranslationConfig(provider="gemini")
+
+    def test_invalid_numeric_values_raise_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "batch_size must be greater than 0"):
+            TranslationConfig(batch_size=0)
+
+        with self.assertRaisesRegex(ValueError, "temperature must be between 0 and 2"):
+            TranslationConfig(temperature=3.0)
+
+    def test_env_api_key_loads_without_leaking_in_safe_outputs(self):
+        config = load_config(
+            cli_args={},
+            env_path=None,
+            environ={"TRANSLATION_API_KEY": "env-secret"},
+        )
+
+        self.assertEqual(config.api_key, "env-secret")
+        safe = config.to_safe_dict()
+        self.assertNotIn("api_key", safe)
+        self.assertNotIn("env-secret", str(safe))
+        self.assertNotIn("env-secret", repr(config))
+
+    def test_system_environment_values_override_env_file_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env"
+            env_path.write_text("TRANSLATION_MODEL=file-model\n", encoding="utf-8")
+
+            config = load_config(
+                cli_args={},
+                env_path=env_path,
+                environ={"TRANSLATION_MODEL": "system-model"},
+            )
+
+        self.assertEqual(config.model, "system-model")
+
+    def test_safe_config_redacts_credentials_when_password_contains_at_symbol(self):
+        config = TranslationConfig(base_url="https://user:p@ssword@example.test/v1")
+
+        safe = config.to_safe_dict()
+
+        self.assertEqual(safe["base_url"], "https://<redacted>@example.test/v1")
+        self.assertNotIn("p@ssword", str(safe))
+
+    def test_invalid_env_numeric_value_names_environment_variable(self):
+        with self.assertRaisesRegex(ValueError, "TRANSLATION_BATCH_SIZE"):
+            load_config(
+                cli_args={},
+                env_path=None,
+                environ={"TRANSLATION_BATCH_SIZE": "abc"},
+            )
+
+    def test_invalid_mode_raises_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "mode must be one of"):
+            TranslationConfig(mode="invalid")
+
+    def test_srt_cue_count_ignores_digit_only_text_lines(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n"
+                "00:00:00,000 --> 00:00:01,000\n"
+                "42\n\n"
+                "2\n"
+                "00:00:02.000 --> 00:00:03.000\n"
+                "done\n\n",
+                encoding="utf-8",
+            )
+
+            result = run_translation_pipeline(subtitle_path, TranslationConfig(dry_run=True))
+
+        self.assertEqual(result.cue_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/translation_config_cases.py
+++ b/tests/translation_config_cases.py
@@ -128,6 +128,61 @@ class TranslationConfigTests(unittest.TestCase):
 
         self.assertEqual(result.cue_count, 2)
 
+    def test_dry_run_uses_parser_and_returns_cue_previews(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n"
+                "00:00:00,000 --> 00:00:01,000\n"
+                "hello\nworld\n\n"
+                "2\n"
+                "00:00:02,000 --> 00:00:03,000\n"
+                "done\n\n",
+                encoding="utf-8",
+            )
+
+            result = run_translation_pipeline(subtitle_path, TranslationConfig(dry_run=True))
+
+        self.assertEqual(result.cue_count, 2)
+        self.assertEqual(result.first_cue_preview, "hello world")
+        self.assertEqual(result.last_cue_preview, "done")
+
+    def test_dry_run_preview_escapes_terminal_control_characters(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello \x1b[2J world\n\n",
+                encoding="utf-8",
+            )
+
+            result = run_translation_pipeline(subtitle_path, TranslationConfig(dry_run=True))
+
+        self.assertNotIn("\x1b", result.first_cue_preview)
+        self.assertEqual(result.first_cue_preview, "hello [2J world")
+
+    def test_dry_run_preview_preserves_unicode_text(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\n你好 world\n\n",
+                encoding="utf-8",
+            )
+
+            result = run_translation_pipeline(subtitle_path, TranslationConfig(dry_run=True))
+
+        self.assertEqual(result.first_cue_preview, "你好 world")
+
+    def test_non_dry_run_remains_unimplemented_after_parser_validation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subtitle_path = Path(temp_dir) / "sample.srt"
+            subtitle_path.write_text(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(NotImplementedError, "provider execution is not implemented"):
+                run_translation_pipeline(subtitle_path, TranslationConfig(dry_run=False))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/translation_provider_cases.py
+++ b/tests/translation_provider_cases.py
@@ -1,0 +1,33 @@
+import unittest
+
+from translation.config import TranslationConfig
+from translation.provider import OpenAICompatibleProvider, TranslationProvider
+
+
+class TranslationProviderTests(unittest.TestCase):
+    def test_openai_compatible_provider_exposes_stable_translation_interface(self):
+        config = TranslationConfig(api_key="test-secret")
+        provider = OpenAICompatibleProvider(config)
+
+        self.assertIsInstance(provider, TranslationProvider)
+        self.assertEqual(provider.model, "deepseek-chat")
+        self.assertEqual(provider.review_model, "deepseek-chat")
+
+    def test_provider_does_not_expose_api_key_as_public_attribute(self):
+        provider = OpenAICompatibleProvider(TranslationConfig(api_key="test-secret"))
+
+        self.assertNotIn("api_key", vars(provider))
+        self.assertNotIn("test-secret", repr(provider))
+
+    def test_provider_placeholder_fails_clearly_without_calling_network(self):
+        provider = OpenAICompatibleProvider(TranslationConfig(api_key="test-secret"))
+
+        with self.assertRaisesRegex(NotImplementedError, "not implemented in this config/CLI section"):
+            provider.translate_batch("prompt")
+
+        with self.assertRaisesRegex(NotImplementedError, "not implemented in this config/CLI section"):
+            provider.review_suspicious("prompt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/translation/__init__.py
+++ b/translation/__init__.py
@@ -1,0 +1,1 @@
+"""Lightweight subtitle translation engine."""

--- a/translation/config.py
+++ b/translation/config.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+
+VALID_MODES = {"fast", "balanced", "publish"}
+
+
+ENV_MAPPING = {
+    "provider": "TRANSLATION_PROVIDER",
+    "base_url": "TRANSLATION_BASE_URL",
+    "api_key": "TRANSLATION_API_KEY",
+    "model": "TRANSLATION_MODEL",
+    "review_model": "TRANSLATION_REVIEW_MODEL",
+    "target_lang": "TRANSLATION_TARGET_LANG",
+    "mode": "TRANSLATION_MODE",
+    "batch_size": "TRANSLATION_BATCH_SIZE",
+    "context_before": "TRANSLATION_CONTEXT_BEFORE",
+    "context_after": "TRANSLATION_CONTEXT_AFTER",
+    "temperature": "TRANSLATION_TEMPERATURE",
+    "max_retries": "TRANSLATION_MAX_RETRIES",
+    "cache_enabled": "TRANSLATION_CACHE",
+    "cache_path": "TRANSLATION_CACHE_PATH",
+    "glossary_path": "TRANSLATION_GLOSSARY_PATH",
+    "qa_mode": "TRANSLATION_QA",
+}
+
+
+@dataclass(frozen=True)
+class TranslationConfig:
+    provider: str = "openai-compatible"
+    base_url: str = "http://127.0.0.1:8317/v1"
+    api_key: str | None = field(default=None, repr=False)
+    model: str = "deepseek-chat"
+    review_model: str | None = None
+    target_lang: str = "zh-CN"
+    mode: str = "balanced"
+    batch_size: int = 80
+    context_before: int = 10
+    context_after: int = 10
+    temperature: float = 0.1
+    max_retries: int = 3
+    cache_enabled: bool = True
+    cache_path: str = ".translation_cache.sqlite3"
+    glossary_path: str = "glossary.md"
+    qa_mode: str = "suspicious-only"
+    output_dir: str | None = None
+    dry_run: bool = False
+    overwrite: bool = False
+
+    def __post_init__(self) -> None:
+        if self.provider != "openai-compatible":
+            raise ValueError("only openai-compatible is supported in B1-lite")
+        object.__setattr__(self, "mode", self.mode.strip().lower())
+        if self.mode not in VALID_MODES:
+            valid_modes = ", ".join(sorted(VALID_MODES))
+            raise ValueError(f"mode must be one of: {valid_modes}")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be greater than 0")
+        if self.context_before < 0:
+            raise ValueError("context_before must be greater than or equal to 0")
+        if self.context_after < 0:
+            raise ValueError("context_after must be greater than or equal to 0")
+        if not 0 <= self.temperature <= 2:
+            raise ValueError("temperature must be between 0 and 2")
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+        if self.qa_mode not in {"suspicious-only", "none"}:
+            raise ValueError("qa_mode must be suspicious-only or none")
+
+    @property
+    def effective_review_model(self) -> str:
+        return self.review_model or self.model
+
+    def to_safe_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "base_url": _redact_url(self.base_url),
+            "model": self.model,
+            "review_model": self.review_model,
+            "effective_review_model": self.effective_review_model,
+            "target_lang": self.target_lang,
+            "mode": self.mode,
+            "batch_size": self.batch_size,
+            "context_before": self.context_before,
+            "context_after": self.context_after,
+            "temperature": self.temperature,
+            "max_retries": self.max_retries,
+            "cache_enabled": self.cache_enabled,
+            "cache_path": self.cache_path,
+            "glossary_path": self.glossary_path,
+            "qa_mode": self.qa_mode,
+            "output_dir": self.output_dir,
+            "dry_run": self.dry_run,
+            "overwrite": self.overwrite,
+        }
+
+
+def load_config(
+    cli_args: Mapping[str, Any] | None = None,
+    env_path: str | Path | None = ".env",
+    environ: Mapping[str, str] | None = None,
+) -> TranslationConfig:
+    env = dict(os.environ if environ is None else environ)
+    if env_path is not None:
+        for key, value in _load_env_file(Path(env_path)).items():
+            env.setdefault(key, value)
+
+    values: dict[str, Any] = {}
+    for field_name, env_name in ENV_MAPPING.items():
+        raw_value = env.get(env_name)
+        if raw_value is not None and raw_value != "":
+            values[field_name] = _coerce_value(field_name, raw_value)
+
+    for field_name, value in (cli_args or {}).items():
+        if value is not None:
+            values[field_name] = value
+
+    return TranslationConfig(**values)
+
+
+def _load_env_file(env_path: Path) -> dict[str, str]:
+    if not env_path.exists():
+        return {}
+
+    try:
+        from dotenv import dotenv_values
+    except ModuleNotFoundError:
+        return _parse_env_file(env_path)
+
+    return {
+        key: value
+        for key, value in dotenv_values(env_path).items()
+        if key and value is not None
+    }
+
+
+def _parse_env_file(env_path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _coerce_value(field_name: str, raw_value: str) -> Any:
+    try:
+        if field_name in {"batch_size", "context_before", "context_after", "max_retries"}:
+            return int(raw_value)
+        if field_name == "temperature":
+            return float(raw_value)
+        if field_name == "cache_enabled":
+            return _parse_bool(raw_value)
+    except ValueError as exc:
+        env_name = ENV_MAPPING.get(field_name, field_name)
+        raise ValueError(f"invalid value for {env_name}: {raw_value!r}") from exc
+    return raw_value
+
+
+def _parse_bool(raw_value: str) -> bool:
+    normalized = raw_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"invalid boolean value: {raw_value}")
+
+
+def _redact_url(url: str) -> str:
+    if "@" not in url:
+        return url
+    scheme, rest = url.split("://", 1) if "://" in url else ("", url)
+    host = rest.rsplit("@", 1)[1]
+    return f"{scheme}://<redacted>@{host}" if scheme else f"<redacted>@{host}"

--- a/translation/models.py
+++ b/translation/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TranslationOutputPaths:
+    output_dir: Path
+    translated_srt: Path
+    bilingual_srt: Path
+    translation_report: Path
+    global_context: Path
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    input_path: Path
+    input_format: str
+    output_format: str
+    output_paths: TranslationOutputPaths
+    dry_run: bool
+    cue_count: int
+    provider_called: bool = False

--- a/translation/models.py
+++ b/translation/models.py
@@ -5,6 +5,23 @@ from pathlib import Path
 
 
 @dataclass(frozen=True)
+class Cue:
+    id: str
+    index: int
+    start: str
+    end: str
+    source: str
+    raw_timing: str | None = None
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class TranslatedCue:
+    cue: Cue
+    translation: str
+
+
+@dataclass(frozen=True)
 class TranslationOutputPaths:
     output_dir: Path
     translated_srt: Path
@@ -22,3 +39,5 @@ class PipelineResult:
     dry_run: bool
     cue_count: int
     provider_called: bool = False
+    first_cue_preview: str | None = None
+    last_cue_preview: str | None = None

--- a/translation/pipeline.py
+++ b/translation/pipeline.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from translation.config import TranslationConfig
+from translation.models import PipelineResult, TranslationOutputPaths
+
+
+def run_translation_pipeline(subtitle_path: str | Path, config: TranslationConfig) -> PipelineResult:
+    input_path = Path(subtitle_path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"subtitle_path not found: {input_path}")
+
+    input_format = _detect_input_format(input_path)
+    output_paths = build_output_paths(input_path, config)
+    _ensure_outputs_do_not_exist(output_paths, config.overwrite)
+
+    cue_count = _count_cues(input_path, input_format)
+
+    if config.dry_run:
+        return PipelineResult(
+            input_path=input_path,
+            input_format=input_format,
+            output_format="srt",
+            output_paths=output_paths,
+            dry_run=True,
+            cue_count=cue_count,
+            provider_called=False,
+        )
+
+    raise NotImplementedError(
+        "Translation provider execution is not implemented in this config/CLI section. "
+        "Use --dry-run for configuration validation."
+    )
+
+
+def build_output_paths(input_path: Path, config: TranslationConfig) -> TranslationOutputPaths:
+    output_dir = Path(config.output_dir) if config.output_dir else input_path.parent / "translated"
+    return TranslationOutputPaths(
+        output_dir=output_dir,
+        translated_srt=output_dir / f"translated.{config.target_lang}.srt",
+        bilingual_srt=output_dir / "bilingual.srt",
+        translation_report=output_dir / "translation_report.md",
+        global_context=output_dir / "global_context.md",
+    )
+
+
+def _ensure_outputs_do_not_exist(paths: TranslationOutputPaths, overwrite: bool) -> None:
+    if overwrite:
+        return
+    candidates = [paths.translated_srt, paths.bilingual_srt, paths.translation_report, paths.global_context]
+    existing = [path for path in candidates if path.exists()]
+    if existing:
+        joined = ", ".join(str(path) for path in existing)
+        raise FileExistsError(f"output file already exists: {joined}. Add --overwrite to replace outputs.")
+
+
+def _detect_input_format(input_path: Path) -> str:
+    suffix = input_path.suffix.lower()
+    if suffix == ".srt":
+        return "srt"
+    if suffix == ".vtt":
+        return "vtt"
+    raise ValueError("subtitle_path must point to .srt or .vtt")
+
+
+def _count_cues(input_path: Path, input_format: str) -> int:
+    content = input_path.read_text(encoding="utf-8-sig")
+    if input_format == "srt":
+        return len(
+            re.findall(
+                r"(?m)^\s*\d+\s*\r?\n\s*\d{2}:\d{2}:\d{2}[,.]\d{3}\s+-->\s+\d{2}:\d{2}:\d{2}[,.]\d{3}",
+                content,
+            )
+        )
+    return content.count("-->")

--- a/translation/pipeline.py
+++ b/translation/pipeline.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import re
+import unicodedata
 from pathlib import Path
 
 from translation.config import TranslationConfig
-from translation.models import PipelineResult, TranslationOutputPaths
+from translation.models import Cue, PipelineResult, TranslationOutputPaths
+from translation.subtitles import detect_subtitle_format, parse_subtitle_file
 
 
 def run_translation_pipeline(subtitle_path: str | Path, config: TranslationConfig) -> PipelineResult:
@@ -12,11 +13,11 @@ def run_translation_pipeline(subtitle_path: str | Path, config: TranslationConfi
     if not input_path.exists():
         raise FileNotFoundError(f"subtitle_path not found: {input_path}")
 
-    input_format = _detect_input_format(input_path)
+    input_format = detect_subtitle_format(input_path)
     output_paths = build_output_paths(input_path, config)
     _ensure_outputs_do_not_exist(output_paths, config.overwrite)
 
-    cue_count = _count_cues(input_path, input_format)
+    cues = parse_subtitle_file(input_path)
 
     if config.dry_run:
         return PipelineResult(
@@ -25,8 +26,10 @@ def run_translation_pipeline(subtitle_path: str | Path, config: TranslationConfi
             output_format="srt",
             output_paths=output_paths,
             dry_run=True,
-            cue_count=cue_count,
+            cue_count=len(cues),
             provider_called=False,
+            first_cue_preview=_preview_cue(cues[0]),
+            last_cue_preview=_preview_cue(cues[-1]),
         )
 
     raise NotImplementedError(
@@ -56,22 +59,13 @@ def _ensure_outputs_do_not_exist(paths: TranslationOutputPaths, overwrite: bool)
         raise FileExistsError(f"output file already exists: {joined}. Add --overwrite to replace outputs.")
 
 
-def _detect_input_format(input_path: Path) -> str:
-    suffix = input_path.suffix.lower()
-    if suffix == ".srt":
-        return "srt"
-    if suffix == ".vtt":
-        return "vtt"
-    raise ValueError("subtitle_path must point to .srt or .vtt")
-
-
-def _count_cues(input_path: Path, input_format: str) -> int:
-    content = input_path.read_text(encoding="utf-8-sig")
-    if input_format == "srt":
-        return len(
-            re.findall(
-                r"(?m)^\s*\d+\s*\r?\n\s*\d{2}:\d{2}:\d{2}[,.]\d{3}\s+-->\s+\d{2}:\d{2}:\d{2}[,.]\d{3}",
-                content,
-            )
-        )
-    return content.count("-->")
+def _preview_cue(cue: Cue) -> str:
+    safe_source = "".join(
+        character
+        for character in cue.source
+        if character.isspace() or not unicodedata.category(character).startswith("C")
+    )
+    preview = " ".join(safe_source.split())
+    if len(preview) <= 80:
+        return preview
+    return f"{preview[:77]}..."

--- a/translation/provider.py
+++ b/translation/provider.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from translation.config import TranslationConfig
+
+
+@runtime_checkable
+class TranslationProvider(Protocol):
+    def translate_batch(self, prompt: str) -> str:
+        ...
+
+    def review_suspicious(self, prompt: str) -> str:
+        ...
+
+
+class OpenAICompatibleProvider(TranslationProvider):
+    def __init__(self, config: TranslationConfig) -> None:
+        self._config = config
+        self.base_url = config.base_url
+        self.model = config.model
+        self.review_model = config.effective_review_model
+        self.temperature = config.temperature
+
+    def translate_batch(self, prompt: str) -> str:
+        raise NotImplementedError("provider execution is not implemented in this config/CLI section")
+
+    def review_suspicious(self, prompt: str) -> str:
+        raise NotImplementedError("provider execution is not implemented in this config/CLI section")

--- a/translation/subtitles.py
+++ b/translation/subtitles.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+from translation.models import Cue
+
+_TIMING_RE = re.compile(
+    r"^(?P<start>\d{2}:\d{2}:\d{2}[,.]\d{3})\s+-->\s+"
+    r"(?P<end>\d{2}:\d{2}:\d{2}[,.]\d{3})(?P<settings>.*)$"
+)
+_SKIP_VTT_BLOCK_PREFIXES = ("NOTE", "STYLE", "REGION")
+
+
+def detect_subtitle_format(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".srt":
+        return "srt"
+    if suffix == ".vtt":
+        return "vtt"
+    raise ValueError("subtitle_path must point to .srt or .vtt")
+
+
+def parse_subtitle_file(path: Path) -> list[Cue]:
+    subtitle_format = detect_subtitle_format(path)
+    content = path.read_text(encoding="utf-8-sig")
+    if subtitle_format == "srt":
+        return parse_srt(content)
+    return parse_vtt(content)
+
+
+def parse_srt(content: str) -> list[Cue]:
+    cues = _parse_blocks(content, is_vtt=False)
+    validate_cues(cues)
+    return cues
+
+
+def parse_vtt(content: str) -> list[Cue]:
+    lines = _normalize_lines(content)
+    if lines and lines[0].lstrip("﻿").startswith("WEBVTT"):
+        lines = lines[1:]
+    cues = _parse_blocks("\n".join(lines), is_vtt=True)
+    validate_cues(cues)
+    return cues
+
+
+def validate_cues(cues: list[Cue]) -> None:
+    if not cues:
+        raise ValueError("subtitle file contains no cues")
+
+    seen_ids: set[str] = set()
+    for expected_index, cue in enumerate(cues, start=1):
+        if cue.index != expected_index:
+            raise ValueError(f"cue index must be {expected_index}, got {cue.index}")
+        if not cue.id.strip():
+            raise ValueError(f"cue index {cue.index} id is empty")
+        if cue.id in seen_ids:
+            raise ValueError(f"duplicate cue id: {cue.id}")
+        seen_ids.add(cue.id)
+        if not cue.start.strip():
+            raise ValueError(f"cue id {cue.id} start is empty")
+        if not cue.end.strip():
+            raise ValueError(f"cue id {cue.id} end is empty")
+        if not cue.source.strip():
+            raise ValueError(f"cue id {cue.id} source is empty")
+
+
+def validate_translations(cues: list[Cue], translations: Mapping[str, str]) -> None:
+    validate_cues(cues)
+    if len(translations) != len(cues):
+        raise ValueError(f"translation count {len(translations)} does not match cue count {len(cues)}")
+
+    for cue in cues:
+        if cue.id not in translations:
+            raise ValueError(f"missing translation for cue id {cue.id}")
+        if not translations[cue.id].strip():
+            raise ValueError(f"translation for cue id {cue.id} is empty")
+
+
+def write_translated_srt(cues: list[Cue], translations: Mapping[str, str], path: Path) -> None:
+    validate_translations(cues, translations)
+    _write_srt_blocks(cues, path, lambda cue: translations[cue.id])
+
+
+def write_bilingual_srt(
+    cues: list[Cue],
+    translations: Mapping[str, str],
+    path: Path,
+    source_first: bool = False,
+) -> None:
+    validate_translations(cues, translations)
+
+    def text_for(cue: Cue) -> str:
+        if source_first:
+            return f"{cue.source}\n{translations[cue.id]}"
+        return f"{translations[cue.id]}\n{cue.source}"
+
+    _write_srt_blocks(cues, path, text_for)
+
+
+def _parse_blocks(content: str, is_vtt: bool) -> list[Cue]:
+    blocks = _split_blocks(content)
+    cues: list[Cue] = []
+    for block in blocks:
+        if is_vtt and _is_skipped_vtt_block(block):
+            continue
+        cue = _parse_block(block, index=len(cues) + 1, is_vtt=is_vtt)
+        if cue is not None:
+            cues.append(cue)
+    return cues
+
+
+def _split_blocks(content: str) -> list[list[str]]:
+    lines = _normalize_lines(content)
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        if line.strip() == "":
+            if current:
+                blocks.append(current)
+                current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def _normalize_lines(content: str) -> list[str]:
+    return content.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def _is_skipped_vtt_block(block: list[str]) -> bool:
+    first = block[0].strip()
+    return any(first == prefix or first.startswith(f"{prefix} ") for prefix in _SKIP_VTT_BLOCK_PREFIXES)
+
+
+def _parse_block(block: list[str], index: int, is_vtt: bool) -> Cue | None:
+    timing_line_index = _find_timing_line_index(block)
+    if timing_line_index is None:
+        return None
+
+    cue_id = _cue_id_for_block(block, timing_line_index, index, is_vtt)
+    raw_timing = block[timing_line_index].strip()
+    match = _TIMING_RE.match(raw_timing)
+    if match is None:
+        return None
+
+    source_lines = block[timing_line_index + 1 :]
+    source = "\n".join(source_lines).strip()
+    return Cue(
+        id=cue_id,
+        index=index,
+        start=_normalize_timestamp(match.group("start")),
+        end=_normalize_timestamp(match.group("end")),
+        source=source,
+        raw_timing=raw_timing,
+    )
+
+
+def _find_timing_line_index(block: list[str]) -> int | None:
+    for index, line in enumerate(block):
+        if _TIMING_RE.match(line.strip()):
+            return index
+    return None
+
+
+def _cue_id_for_block(block: list[str], timing_line_index: int, index: int, is_vtt: bool) -> str:
+    if timing_line_index == 0:
+        return str(index)
+    candidate = block[timing_line_index - 1].strip()
+    if not candidate:
+        return str(index)
+    if is_vtt:
+        return candidate
+    if timing_line_index == 1 and candidate.isdigit():
+        return candidate
+    return str(index)
+
+
+def _normalize_timestamp(value: str) -> str:
+    return value.replace(".", ",")
+
+
+def _write_srt_blocks(cues: list[Cue], path: Path, text_for: Callable[[Cue], str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    blocks = []
+    for cue in cues:
+        blocks.append(f"{cue.index}\n{cue.start} --> {cue.end}\n{text_for(cue)}\n\n")
+    path.write_text("".join(blocks), encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add immutable Cue/TranslatedCue models plus pure-Python SRT/VTT parsing and validation.
- Add translated SRT and bilingual SRT writer helpers with translation validation.
- Update dry-run pipeline to use real parser cue_count and short sanitized previews.

## Scope
This PR implements subtitle data layer only: SRT/VTT parsing, Cue models, validation, and SRT/bilingual writing helpers. Provider execution remains intentionally unimplemented and will be added in PR3.

## Not included
- OpenAI-compatible HTTP requests or DeepSeek calls
- cache/glossary/context/QA/report implementation
- ASS/SSA, GUI, TTS, or video synthesis

## Test plan
- [x] python -m unittest discover -s tests -p "*_cases.py" -v
- [x] python scripts/translate_subtitles_v2.py --help
- [x] python -m compileall translation scripts/translate_subtitles_v2.py