### PR TITLE
feat: add fresh Firefox cookie export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yt-dlp>=2024.01.01
+pysrt>=1.1.2
+python-dotenv>=1.0.0

--- a/scripts/download_video.py
+++ b/scripts/download_video.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
 """
 下载 YouTube 视频和字幕
-使用 yt-dlp 下载视频（最高 1080p）和英文字幕
+使用 yt-dlp 下载视频和英文字幕
 """
 
-import sys
+from __future__ import annotations
+
+import argparse
 import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime
 from pathlib import Path
+from typing import TypedDict
+
+from dotenv import dotenv_values
 
 try:
     import yt_dlp
@@ -16,195 +26,400 @@ except ImportError:
     sys.exit(1)
 
 from utils import (
-    validate_url,
-    sanitize_filename,
+    ensure_directory,
     format_file_size,
     get_video_duration_display,
-    ensure_directory
+    validate_url,
 )
 
 
-def download_video(url: str, output_dir: str = None) -> dict:
-    """
-    下载 YouTube 视频和字幕
+class DownloadSettings(TypedDict):
+    cookies_from_browser: str | None
+    cookies_file: str | None
+    fresh_firefox_cookies: bool
+    fresh_firefox_profile: str | None
+    fresh_firefox_cookiefile: str | None
+    keep_temp_cookies: bool
+    proxy: str | None
+    rate_limit: str | None
+    max_video_height: str
+    output_dir: str
 
-    Args:
-        url: YouTube URL
-        output_dir: 输出目录，默认为当前目录
 
-    Returns:
-        dict: {
-            'video_path': 视频文件路径,
-            'subtitle_path': 字幕文件路径,
-            'title': 视频标题,
-            'duration': 视频时长（秒）,
-            'file_size': 文件大小（字节）
-        }
+class DownloadResult(TypedDict):
+    video_path: str
+    subtitle_path: str | None
+    title: str
+    duration: int
+    file_size: int
+    video_id: str
 
-    Raises:
-        ValueError: 无效的 URL
-        Exception: 下载失败
-    """
-    # 验证 URL
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download YouTube video, subtitles, and metadata.")
+    parser.add_argument("youtube_url", help="YouTube URL")
+    parser.add_argument("output_dir", nargs="?", help="Output directory")
+    parser.add_argument("--cookies-from-browser", dest="cookies_from_browser", help="Browser source for yt-dlp cookies, e.g. firefox")
+    parser.add_argument("--cookies-file", dest="cookies_file", help="Netscape cookies.txt file path for yt-dlp")
+    parser.add_argument("--fresh-firefox-cookies", action="store_true", help="Export fresh Firefox cookies into a temporary cookies.txt for this download")
+    parser.add_argument("--fresh-firefox-profile", dest="fresh_firefox_profile", help="Firefox profile for fresh cookie export")
+    parser.add_argument("--keep-temp-cookies", action="store_true", help="Keep temporary fresh Firefox cookies.txt after download")
+    parser.add_argument("--proxy", help="Proxy URL for yt-dlp")
+    parser.add_argument("--rate-limit", dest="rate_limit", help="Download rate limit for yt-dlp, e.g. 50K or 4.2M")
+    parser.add_argument("--env-file", default=".env", help="Path to .env file")
+    return parser.parse_args(argv)
+
+
+def _load_env_values(env_file: str) -> dict[str, str]:
+    return {key: value for key, value in dotenv_values(env_file).items() if value is not None}
+
+
+def _resolve_cli_or_env(cli_value: str | None, env_name: str, env_values: dict[str, str]) -> str | None:
+    if cli_value:
+        return cli_value
+    env_value = os.getenv(env_name)
+    if env_value:
+        return env_value
+    file_value = env_values.get(env_name)
+    return file_value or None
+
+
+def _resolve_bool_cli_or_env(cli_value: bool, env_name: str, env_values: dict[str, str]) -> bool:
+    if cli_value:
+        return True
+    env_value = os.getenv(env_name)
+    if env_value is None:
+        env_value = env_values.get(env_name)
+    if env_value is None:
+        return False
+    return env_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _create_temp_cookiefile() -> Path:
+    descriptor, cookiefile_path = tempfile.mkstemp(suffix=".txt", prefix="yt-dlp-fresh-cookies-")
+    os.close(descriptor)
+    try:
+        os.chmod(cookiefile_path, 0o600)
+    except OSError:
+        pass
+    return Path(cookiefile_path)
+
+
+def _resolve_max_video_height(env_values: dict[str, str] | None = None) -> str:
+    if env_values is None:
+        env_values = {}
+    height = os.getenv("MAX_VIDEO_HEIGHT")
+    if height is None:
+        height = env_values.get("MAX_VIDEO_HEIGHT")
+    if height is None or not height.strip():
+        return "1080"
+    height = height.strip()
+    if not height.isdigit():
+        raise ValueError(f"MAX_VIDEO_HEIGHT must be an integer: {height}")
+    return height
+
+
+def _parse_browser_spec(spec: str) -> tuple[str, ...]:
+    parts = tuple(part for part in spec.split(":") if part)
+    if not parts:
+        raise ValueError("cookies-from-browser must not be empty")
+    return parts
+
+
+def _normalize_output_dir(path: str | Path) -> str:
+    return str(Path(str(path).strip()).expanduser())
+
+
+def _timestamped_output_dir(base_dir: str | Path) -> str:
+    return str(Path(_normalize_output_dir(base_dir)) / datetime.now().strftime("%Y%m%d_%H%M%S"))
+
+
+def _resolve_output_dir(cli_output_dir: str | None, env_values: dict[str, str] | None = None) -> str:
+    if cli_output_dir:
+        return _normalize_output_dir(cli_output_dir)
+    if env_values is None:
+        env_values = {}
+    env_output_dir = os.getenv("OUTPUT_DIR")
+    if env_output_dir is None:
+        env_output_dir = env_values.get("OUTPUT_DIR")
+    if env_output_dir and env_output_dir.strip():
+        return _timestamped_output_dir(env_output_dir)
+    return _timestamped_output_dir(Path("youtube-clips"))
+
+
+def _cleanup_temp_cookiefile(cookiefile: Path | None, keep_temp_cookies: bool) -> None:
+    if cookiefile is None:
+        return
+    if keep_temp_cookies:
+        print("[WARN] 保留临时 cookies 文件", file=sys.stderr)
+        return
+    try:
+        cookiefile.unlink(missing_ok=True)
+    except OSError:
+        print("[WARN] 清理临时 cookies 文件失败", file=sys.stderr)
+
+
+def _validate_cookie_sources(
+    cookies_from_browser: str | None,
+    cookies_file: str | None,
+    fresh_firefox_cookies: bool,
+) -> None:
+    if cookies_from_browser and cookies_file:
+        raise ValueError("--cookies-from-browser and --cookies-file are mutually exclusive")
+    if fresh_firefox_cookies and (cookies_from_browser or cookies_file):
+        raise ValueError("--fresh-firefox-cookies is mutually exclusive with --cookies-from-browser and --cookies-file")
+
+
+def resolve_download_settings(
+    args: argparse.Namespace,
+    env_values: dict[str, str] | None = None,
+) -> DownloadSettings:
+    if env_values is None:
+        env_values = _load_env_values(args.env_file)
+
+    cookies_from_browser = _resolve_cli_or_env(args.cookies_from_browser, "YT_DLP_COOKIES_FROM_BROWSER", env_values)
+    cookies_file = _resolve_cli_or_env(args.cookies_file, "YT_DLP_COOKIES_FILE", env_values)
+    fresh_firefox_cookies = _resolve_bool_cli_or_env(args.fresh_firefox_cookies, "YT_DLP_FRESH_FIREFOX_COOKIES", env_values)
+    fresh_firefox_profile = _resolve_cli_or_env(args.fresh_firefox_profile, "YT_DLP_FRESH_FIREFOX_PROFILE", env_values)
+    keep_temp_cookies = _resolve_bool_cli_or_env(args.keep_temp_cookies, "YT_DLP_KEEP_TEMP_COOKIES", env_values)
+    proxy = _resolve_cli_or_env(args.proxy, "YT_DLP_PROXY", env_values)
+    rate_limit = _resolve_cli_or_env(args.rate_limit, "YT_DLP_RATE_LIMIT", env_values)
+    max_video_height = _resolve_max_video_height(env_values)
+    output_dir = _resolve_output_dir(args.output_dir, env_values)
+
+    if fresh_firefox_profile and not fresh_firefox_cookies:
+        fresh_firefox_cookies = True
+    _validate_cookie_sources(cookies_from_browser, cookies_file, fresh_firefox_cookies)
+
+    resolved_cookie_file = None
+    if cookies_file:
+        cookie_path = Path(cookies_file).expanduser().resolve()
+        if not cookie_path.is_file():
+            raise FileNotFoundError(f"Cookies file not found: {cookie_path}")
+        resolved_cookie_file = str(cookie_path)
+
+    return {
+        "cookies_from_browser": cookies_from_browser,
+        "cookies_file": resolved_cookie_file,
+        "fresh_firefox_cookies": fresh_firefox_cookies,
+        "fresh_firefox_profile": fresh_firefox_profile,
+        "fresh_firefox_cookiefile": None,
+        "keep_temp_cookies": keep_temp_cookies,
+        "proxy": proxy,
+        "rate_limit": rate_limit,
+        "max_video_height": max_video_height,
+        "output_dir": output_dir,
+    }
+
+
+def _sanitize_error_message(message: str, proxy: str | None) -> str:
+    sanitized = message
+    if proxy:
+        sanitized = sanitized.replace(proxy, "<redacted-proxy>")
+    sanitized = re.sub(r"(?i)([a-z][a-z0-9+.-]*://)[^/\s]+@", r"\1<redacted-proxy>@", sanitized)
+    return re.sub(r"(?<![\w/:])[^\s/@:]+:[^\s/]+@", "<redacted-userinfo>@", sanitized)
+
+
+def build_ydl_opts(output_dir: Path, settings: DownloadSettings) -> dict[str, object]:
+    uses_fresh_firefox_cookies = settings["fresh_firefox_cookies"] or settings["fresh_firefox_profile"] is not None
+    _validate_cookie_sources(settings["cookies_from_browser"], settings["cookies_file"], uses_fresh_firefox_cookies)
+    max_video_height = settings["max_video_height"]
+    ydl_opts = {
+        "format": f"bestvideo[height<={max_video_height}][ext=mp4]+bestaudio[ext=m4a]/best[height<={max_video_height}][ext=mp4]/best",
+        "outtmpl": str(output_dir / "%(id)s.%(ext)s"),
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitleslangs": ["en"],
+        "subtitlesformat": "vtt",
+        "writethumbnail": False,
+        "quiet": False,
+        "no_warnings": False,
+        "progress_hooks": [_progress_hook],
+    }
+
+    cookies_from_browser = settings["cookies_from_browser"]
+    cookies_file = settings["cookies_file"]
+    fresh_firefox_cookies = settings["fresh_firefox_cookies"]
+    fresh_firefox_profile = settings["fresh_firefox_profile"]
+    fresh_firefox_cookiefile = settings["fresh_firefox_cookiefile"]
+    proxy = settings["proxy"]
+    rate_limit = settings["rate_limit"]
+
+    if fresh_firefox_cookies:
+        browser_spec = ("firefox", fresh_firefox_profile) if fresh_firefox_profile else ("firefox",)
+        ydl_opts["cookiesfrombrowser"] = browser_spec
+        if fresh_firefox_cookiefile:
+            ydl_opts["cookiefile"] = fresh_firefox_cookiefile
+    else:
+        if cookies_from_browser:
+            ydl_opts["cookiesfrombrowser"] = _parse_browser_spec(cookies_from_browser)
+        if cookies_file:
+            ydl_opts["cookiefile"] = cookies_file
+
+    if proxy:
+        ydl_opts["proxy"] = proxy
+    if rate_limit:
+        ydl_opts["ratelimit"] = rate_limit
+
+    return ydl_opts
+
+
+def download_video(
+    url: str,
+    output_dir: str | None = None,
+    *,
+    cookies_from_browser: str | None = None,
+    cookies_file: str | None = None,
+    fresh_firefox_cookies: bool = False,
+    fresh_firefox_profile: str | None = None,
+    fresh_firefox_cookiefile: str | None = None,
+    keep_temp_cookies: bool = False,
+    proxy: str | None = None,
+    rate_limit: str | None = None,
+    max_video_height: str = "1080",
+) -> DownloadResult:
     if not validate_url(url):
         raise ValueError(f"Invalid YouTube URL: {url}")
 
-    # 设置输出目录
+    uses_fresh_firefox_cookies = fresh_firefox_cookies or fresh_firefox_profile is not None
+    _validate_cookie_sources(cookies_from_browser, cookies_file, uses_fresh_firefox_cookies)
+
     if output_dir is None:
-        output_dir = Path.cwd()
+        resolved_output_dir = Path(_resolve_output_dir(None))
     else:
-        output_dir = Path(output_dir)
+        resolved_output_dir = Path(_normalize_output_dir(output_dir))
 
-    output_dir = ensure_directory(output_dir)
+    resolved_output_dir = ensure_directory(resolved_output_dir)
 
-    print(f"🎬 开始下载视频...")
+    print("[INFO] 开始下载视频...")
     print(f"   URL: {url}")
-    print(f"   输出目录: {output_dir}")
+    print(f"   输出目录: {resolved_output_dir}")
 
-    # 配置 yt-dlp 选项
-    ydl_opts = {
-        # 视频格式：最高 1080p，优先 mp4
-        'format': 'bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best',
-
-        # 输出模板：包含视频 ID（避免特殊字符问题）
-        'outtmpl': str(output_dir / '%(id)s.%(ext)s'),
-
-        # 下载字幕
-        'writesubtitles': True,
-        'writeautomaticsub': True,  # 自动字幕作为备选
-        'subtitleslangs': ['en'],   # 英文字幕
-        'subtitlesformat': 'vtt',   # VTT 格式
-
-        # 不下载缩略图
-        'writethumbnail': False,
-
-        # 静默模式（减少输出）
-        'quiet': False,
-        'no_warnings': False,
-
-        # 进度钩子
-        'progress_hooks': [_progress_hook],
+    resolved_fresh_cookiefile = fresh_firefox_cookiefile
+    created_temp_cookiefile: Path | None = None
+    if uses_fresh_firefox_cookies and resolved_fresh_cookiefile is None:
+        created_temp_cookiefile = _create_temp_cookiefile()
+        resolved_fresh_cookiefile = str(created_temp_cookiefile)
+    settings: DownloadSettings = {
+        "cookies_from_browser": cookies_from_browser,
+        "cookies_file": cookies_file,
+        "fresh_firefox_cookies": uses_fresh_firefox_cookies,
+        "fresh_firefox_profile": fresh_firefox_profile,
+        "fresh_firefox_cookiefile": resolved_fresh_cookiefile,
+        "keep_temp_cookies": keep_temp_cookies,
+        "proxy": proxy,
+        "rate_limit": rate_limit,
+        "max_video_height": max_video_height,
+        "output_dir": str(resolved_output_dir),
     }
+    ydl_opts = build_ydl_opts(resolved_output_dir, settings)
 
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            # 提取信息
-            print("\n📊 获取视频信息...")
+            print("\n[INFO] 获取视频信息...")
             info = ydl.extract_info(url, download=False)
 
-            title = info.get('title', 'Unknown')
-            duration = info.get('duration', 0)
-            video_id = info.get('id', 'unknown')
+            title = info.get("title", "Unknown")
+            duration = info.get("duration", 0)
+            video_id = info.get("id", "unknown")
 
             print(f"   标题: {title}")
             print(f"   时长: {get_video_duration_display(duration)}")
             print(f"   视频ID: {video_id}")
 
-            # 下载视频
-            print(f"\n📥 开始下载...")
+            print("\n[INFO] 开始下载...")
             info = ydl.extract_info(url, download=True)
 
-            # 获取下载的文件路径
             video_filename = ydl.prepare_filename(info)
             video_path = Path(video_filename)
 
-            # 查找字幕文件
             subtitle_path = None
-            subtitle_exts = ['.en.vtt', '.vtt']
-            for ext in subtitle_exts:
-                potential_sub = video_path.with_suffix(ext)
-                # 处理带语言代码的字幕文件
-                if not potential_sub.exists():
-                    # 尝试 <filename>.en.vtt 格式
-                    stem = video_path.stem
-                    potential_sub = video_path.parent / f"{stem}.en.vtt"
-
+            for potential_sub in (video_path.with_suffix(".en.vtt"), video_path.with_suffix(".vtt")):
                 if potential_sub.exists():
                     subtitle_path = potential_sub
                     break
 
-            # 获取文件大小
             file_size = video_path.stat().st_size if video_path.exists() else 0
 
-            # 验证下载结果
             if not video_path.exists():
                 raise Exception("Video file not found after download")
 
-            print(f"\n✅ 视频下载完成: {video_path.name}")
+            print(f"\n[OK] 视频下载完成: {video_path.name}")
             print(f"   大小: {format_file_size(file_size)}")
 
             if subtitle_path and subtitle_path.exists():
-                print(f"✅ 字幕下载完成: {subtitle_path.name}")
+                print(f"[OK] 字幕下载完成: {subtitle_path.name}")
             else:
-                print(f"⚠️  未找到英文字幕")
-                print(f"   提示：某些视频可能没有字幕或需要自动生成")
+                print("[WARN] 未找到英文字幕")
+                print("   提示：某些视频可能没有字幕或需要自动生成")
 
             return {
-                'video_path': str(video_path),
-                'subtitle_path': str(subtitle_path) if subtitle_path else None,
-                'title': title,
-                'duration': duration,
-                'file_size': file_size,
-                'video_id': video_id
+                "video_path": str(video_path),
+                "subtitle_path": str(subtitle_path) if subtitle_path else None,
+                "title": title,
+                "duration": duration,
+                "file_size": file_size,
+                "video_id": video_id,
             }
+    except Exception as exc:
+        raise RuntimeError(_sanitize_error_message(str(exc), proxy)) from exc
+    finally:
+        _cleanup_temp_cookiefile(created_temp_cookiefile, keep_temp_cookies)
 
-    except Exception as e:
-        print(f"\n❌ 下载失败: {str(e)}")
-        raise
 
+def _progress_hook(progress: dict) -> None:
+    if progress["status"] == "downloading":
+        if "downloaded_bytes" in progress and "total_bytes" in progress and progress["total_bytes"]:
+            percent = progress["downloaded_bytes"] / progress["total_bytes"] * 100
+            downloaded = format_file_size(progress["downloaded_bytes"])
+            total = format_file_size(progress["total_bytes"])
+            speed = progress.get("speed", 0)
+            speed_str = format_file_size(speed) + "/s" if speed else "N/A"
 
-def _progress_hook(d):
-    """下载进度回调"""
-    if d['status'] == 'downloading':
-        # 显示下载进度
-        if 'downloaded_bytes' in d and 'total_bytes' in d and d['total_bytes']:
-            percent = d['downloaded_bytes'] / d['total_bytes'] * 100
-            downloaded = format_file_size(d['downloaded_bytes'])
-            total = format_file_size(d['total_bytes'])
-            speed = d.get('speed', 0)
-            speed_str = format_file_size(speed) + '/s' if speed else 'N/A'
-
-            # 使用 \r 实现进度条覆盖
             bar_length = 30
             filled = int(bar_length * percent / 100)
-            bar = '█' * filled + '░' * (bar_length - filled)
+            bar = "#" * filled + "-" * (bar_length - filled)
 
-            print(f"\r   [{bar}] {percent:.1f}% - {downloaded}/{total} - {speed_str}", end='', flush=True)
-        elif 'downloaded_bytes' in d:
-            # 无总大小信息时，只显示已下载
-            downloaded = format_file_size(d['downloaded_bytes'])
-            speed = d.get('speed', 0)
-            speed_str = format_file_size(speed) + '/s' if speed else 'N/A'
-            print(f"\r   下载中... {downloaded} - {speed_str}", end='', flush=True)
-
-    elif d['status'] == 'finished':
-        print()  # 换行
+            print(f"\r   [{bar}] {percent:.1f}% - {downloaded}/{total} - {speed_str}", end="", flush=True)
+        elif "downloaded_bytes" in progress:
+            downloaded = format_file_size(progress["downloaded_bytes"])
+            speed = progress.get("speed", 0)
+            speed_str = format_file_size(speed) + "/s" if speed else "N/A"
+            print(f"\r   下载中... {downloaded} - {speed_str}", end="", flush=True)
+    elif progress["status"] == "finished":
+        print()
 
 
-def main():
-    """命令行入口"""
-    if len(sys.argv) < 2:
-        print("Usage: python download_video.py <youtube_url> [output_dir]")
-        print("\nExample:")
-        print("  python download_video.py https://youtube.com/watch?v=Ckt1cj0xjRM")
-        print("  python download_video.py https://youtube.com/watch?v=Ckt1cj0xjRM ~/Downloads")
-        sys.exit(1)
-
-    url = sys.argv[1]
-    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    env_values = _load_env_values(args.env_file)
+    settings: DownloadSettings | None = None
 
     try:
-        result = download_video(url, output_dir)
-
-        # 输出 JSON 结果（供其他脚本使用）
-        print("\n" + "="*60)
+        settings = resolve_download_settings(args, env_values)
+        result = download_video(
+            args.youtube_url,
+            settings["output_dir"],
+            cookies_from_browser=settings["cookies_from_browser"],
+            cookies_file=settings["cookies_file"],
+            fresh_firefox_cookies=settings["fresh_firefox_cookies"],
+            fresh_firefox_profile=settings["fresh_firefox_profile"],
+            fresh_firefox_cookiefile=settings["fresh_firefox_cookiefile"],
+            keep_temp_cookies=settings["keep_temp_cookies"],
+            proxy=settings["proxy"],
+            rate_limit=settings["rate_limit"],
+            max_video_height=settings["max_video_height"],
+        )
+        print("\n" + "=" * 60)
         print("下载结果 (JSON):")
         print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    except Exception as e:
-        print(f"\n❌ 错误: {str(e)}")
-        sys.exit(1)
+        return 0
+    except Exception as exc:
+        resolved_proxy = settings["proxy"] if settings is not None else _resolve_cli_or_env(args.proxy, "YT_DLP_PROXY", env_values)
+        sanitized_message = _sanitize_error_message(str(exc), resolved_proxy)
+        print(f"\n[ERROR] 错误: {sanitized_message}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/download_video_cases.py
+++ b/tests/download_video_cases.py
@@ -1,0 +1,922 @@
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "download_video.py"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import download_video
+
+
+class DownloadVideoCliTests(unittest.TestCase):
+    def test_help_displays_cookie_arguments(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("youtube_url", result.stdout)
+        self.assertIn("--cookies-from-browser", result.stdout)
+        self.assertIn("--cookies-file", result.stdout)
+        self.assertIn("--fresh-firefox-cookies", result.stdout)
+        self.assertIn("--fresh-firefox-profile", result.stdout)
+        self.assertIn("--keep-temp-cookies", result.stdout)
+        self.assertIn("--proxy", result.stdout)
+        self.assertIn("--rate-limit", result.stdout)
+        self.assertIn("--env-file", result.stdout)
+
+
+class DownloadVideoSettingsTests(unittest.TestCase):
+    def test_cookies_from_browser_sets_ydl_opt(self):
+        settings = {
+            "cookies_from_browser": "firefox",
+            "cookies_file": None,
+            "fresh_firefox_cookies": False,
+            "fresh_firefox_profile": None,
+            "fresh_firefox_cookiefile": None,
+            "keep_temp_cookies": False,
+            "proxy": None,
+            "rate_limit": None,
+            "max_video_height": "1080",
+            "output_dir": "out",
+        }
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+
+        self.assertEqual(options["cookiesfrombrowser"], ("firefox",))
+
+    def test_cookies_file_sets_ydl_opt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--cookies-file",
+                    str(cookie_path),
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+        self.assertEqual(options["cookiefile"], str(cookie_path.resolve()))
+
+    def test_cookies_mutual_exclusion_raises(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--cookies-from-browser",
+                    "firefox",
+                    "--cookies-file",
+                    str(cookie_path),
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                    download_video.resolve_download_settings(args)
+
+    def test_fresh_firefox_cookies_conflicts_with_cookies_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--fresh-firefox-cookies",
+                    "--cookies-file",
+                    str(cookie_path),
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                    download_video.resolve_download_settings(args)
+
+    def test_fresh_firefox_cookies_conflicts_with_cookies_from_browser(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--fresh-firefox-cookies",
+                    "--cookies-from-browser",
+                    "firefox",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                    download_video.resolve_download_settings(args)
+
+    def test_fresh_firefox_profile_conflicts_with_cookies_from_browser(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--fresh-firefox-profile",
+                    "work",
+                    "--cookies-from-browser",
+                    "firefox",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                    download_video.resolve_download_settings(args)
+
+    def test_cookies_file_missing_raises(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "missing.txt"
+            env_path = Path(temp_dir) / "empty.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--cookies-file",
+                    str(missing),
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(FileNotFoundError, "Cookies file not found"):
+                    download_video.resolve_download_settings(args)
+
+    def test_proxy_from_cli_overrides_env(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text("YT_DLP_PROXY=http://env-proxy:8080\n", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--proxy",
+                    "http://cli-proxy:8080",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertEqual(settings["proxy"], "http://cli-proxy:8080")
+
+    def test_rate_limit_from_env_fallback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text("YT_DLP_RATE_LIMIT=50K\n", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertEqual(settings["rate_limit"], "50K")
+
+    def test_empty_max_video_height_uses_default(self):
+        with patch.dict(os.environ, {"MAX_VIDEO_HEIGHT": ""}, clear=True):
+            self.assertEqual(download_video._resolve_max_video_height(), "1080")
+
+    def test_max_video_height_strips_whitespace_before_validation(self):
+        with patch.dict(os.environ, {"MAX_VIDEO_HEIGHT": " 720 "}, clear=True):
+            self.assertEqual(download_video._resolve_max_video_height(), "720")
+
+    def test_non_numeric_max_video_height_error_includes_value(self):
+        with patch.dict(os.environ, {"MAX_VIDEO_HEIGHT": "large"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "large"):
+                download_video._resolve_max_video_height()
+
+    def test_cli_output_dir_overrides_env_output_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cli_output_dir = Path(temp_dir) / "cli-out"
+            env_output_dir = Path(temp_dir) / "env-out"
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    str(cli_output_dir),
+                    "--env-file",
+                    str(Path(temp_dir) / "missing.env"),
+                ]
+            )
+
+            with patch.dict(os.environ, {"OUTPUT_DIR": str(env_output_dir)}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertEqual(settings["output_dir"], str(cli_output_dir))
+
+    def test_env_output_dir_adds_timestamp_child(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_output_dir = Path(temp_dir) / "env-out"
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--env-file",
+                    str(Path(temp_dir) / "missing.env"),
+                ]
+            )
+
+            with patch.dict(os.environ, {"OUTPUT_DIR": str(env_output_dir)}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        output_dir = Path(settings["output_dir"])
+        self.assertEqual(output_dir.parent, env_output_dir)
+        self.assertRegex(output_dir.name, r"^\d{8}_\d{6}$")
+
+    def test_env_output_dir_expands_home_directory(self):
+        home_dir = str(Path.home())
+        args = download_video.parse_args(
+            [
+                "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                "--env-file",
+                str(Path.cwd() / "missing.env"),
+            ]
+        )
+
+        with patch.dict(os.environ, {"OUTPUT_DIR": "~/Downloads", "USERPROFILE": home_dir, "HOME": home_dir}, clear=True):
+            settings = download_video.resolve_download_settings(args)
+
+        output_dir = Path(settings["output_dir"])
+        self.assertEqual(output_dir.parent, Path.home() / "Downloads")
+        self.assertRegex(output_dir.name, r"^\d{8}_\d{6}$")
+
+    def test_cli_output_dir_expands_home_directory(self):
+        home_dir = str(Path.home())
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "~/Downloads",
+                    "--env-file",
+                    str(Path(temp_dir) / "missing.env"),
+                ]
+            )
+
+            with patch.dict(os.environ, {"USERPROFILE": home_dir, "HOME": home_dir}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertEqual(Path(settings["output_dir"]), Path.home() / "Downloads")
+
+    def test_default_output_dir_uses_youtube_clips_timestamp(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--env-file",
+                    str(Path(temp_dir) / "missing.env"),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        output_dir = Path(settings["output_dir"])
+        self.assertEqual(output_dir.parent.name, "youtube-clips")
+        self.assertRegex(output_dir.name, r"^\d{8}_\d{6}$")
+        self.assertNotEqual(output_dir, Path.cwd())
+
+    def test_env_file_flag_loads_specified_dotenv(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text("YT_DLP_COOKIES_FROM_BROWSER=firefox\n", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertEqual(settings["cookies_from_browser"], "firefox")
+
+    def test_fresh_firefox_env_flags_resolve(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text(
+                "YT_DLP_FRESH_FIREFOX_COOKIES=true\n"
+                "YT_DLP_FRESH_FIREFOX_PROFILE=work\n"
+                "YT_DLP_KEEP_TEMP_COOKIES=1\n",
+                encoding="utf-8",
+            )
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertTrue(settings["fresh_firefox_cookies"])
+        self.assertEqual(settings["fresh_firefox_profile"], "work")
+        self.assertTrue(settings["keep_temp_cookies"])
+        self.assertIsNone(settings["fresh_firefox_cookiefile"])
+
+    def test_fresh_firefox_profile_enables_fresh_mode(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text("", encoding="utf-8")
+            args = download_video.parse_args(
+                [
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    "--fresh-firefox-profile",
+                    "work",
+                    "--env-file",
+                    str(env_path),
+                ]
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                settings = download_video.resolve_download_settings(args)
+
+        self.assertTrue(settings["fresh_firefox_cookies"])
+        self.assertEqual(settings["fresh_firefox_profile"], "work")
+        self.assertIsNone(settings["fresh_firefox_cookiefile"])
+
+    def test_fresh_firefox_cookies_sets_ydl_opts(self):
+        settings = {
+            "cookies_from_browser": None,
+            "cookies_file": None,
+            "fresh_firefox_cookies": True,
+            "fresh_firefox_profile": None,
+            "fresh_firefox_cookiefile": str(Path(tempfile.gettempdir()) / "fresh-firefox-cookies.txt"),
+            "keep_temp_cookies": False,
+            "proxy": None,
+            "rate_limit": None,
+            "max_video_height": "1080",
+            "output_dir": "out",
+        }
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+
+        self.assertEqual(options["cookiesfrombrowser"], ("firefox",))
+        self.assertEqual(options["cookiefile"], str(Path(tempfile.gettempdir()) / "fresh-firefox-cookies.txt"))
+
+    def test_fresh_firefox_profile_sets_ydl_opts(self):
+        settings = {
+            "cookies_from_browser": None,
+            "cookies_file": None,
+            "fresh_firefox_cookies": True,
+            "fresh_firefox_profile": "work",
+            "fresh_firefox_cookiefile": str(Path(tempfile.gettempdir()) / "fresh-firefox-cookies.txt"),
+            "keep_temp_cookies": False,
+            "proxy": None,
+            "rate_limit": None,
+            "max_video_height": "1080",
+            "output_dir": "out",
+        }
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+
+        self.assertEqual(options["cookiesfrombrowser"], ("firefox", "work"))
+        self.assertEqual(options["cookiefile"], str(Path(tempfile.gettempdir()) / "fresh-firefox-cookies.txt"))
+
+    def test_none_values_omitted_from_ydl_opts(self):
+        settings = {
+            "cookies_from_browser": None,
+            "cookies_file": None,
+            "fresh_firefox_cookies": False,
+            "fresh_firefox_profile": None,
+            "fresh_firefox_cookiefile": None,
+            "keep_temp_cookies": False,
+            "proxy": None,
+            "rate_limit": None,
+            "max_video_height": "1080",
+            "output_dir": "out",
+        }
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+
+        self.assertNotIn("cookiesfrombrowser", options)
+        self.assertNotIn("cookiefile", options)
+        self.assertNotIn("proxy", options)
+        self.assertNotIn("ratelimit", options)
+
+    def test_max_video_height_affects_format(self):
+        settings = {
+            "cookies_from_browser": None,
+            "cookies_file": None,
+            "fresh_firefox_cookies": False,
+            "fresh_firefox_profile": None,
+            "fresh_firefox_cookiefile": None,
+            "keep_temp_cookies": False,
+            "proxy": None,
+            "rate_limit": None,
+            "max_video_height": "2160",
+            "output_dir": "out",
+        }
+
+        options = download_video.build_ydl_opts(Path("out"), settings)
+
+        self.assertIn("height<=2160", options["format"])
+
+
+class DownloadVideoExecutionTests(unittest.TestCase):
+    def test_sanitize_error_message_redacts_exact_proxy_credentials(self):
+        message = "proxy failed: http://user:secret@proxy.example:8080 timeout"
+
+        sanitized = download_video._sanitize_error_message(message, "http://user:secret@proxy.example:8080")
+
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("<redacted-proxy>", sanitized)
+
+    def test_sanitize_error_message_redacts_proxy_with_trailing_slash(self):
+        message = "proxy failed: http://user:secret@proxy.example:8080/ timeout"
+
+        sanitized = download_video._sanitize_error_message(message, "http://user:secret@proxy.example:8080")
+
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("<redacted-proxy>/", sanitized)
+
+    def test_sanitize_error_message_redacts_proxy_userinfo_without_scheme(self):
+        message = "proxy failed: user:secret@proxy.example:8080 timeout"
+
+        sanitized = download_video._sanitize_error_message(message, "http://user:secret@proxy.example:8080")
+
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("<redacted-userinfo>@proxy.example:8080", sanitized)
+
+    def test_sanitize_error_message_redacts_password_containing_at_symbol(self):
+        message = "proxy failed: http://user:p@ss@proxy.example:8080/ timeout"
+
+        sanitized = download_video._sanitize_error_message(message, None)
+
+        self.assertNotIn("p@ss", sanitized)
+        self.assertNotIn("ss@proxy", sanitized)
+        self.assertIn("http://<redacted-proxy>@proxy.example:8080/", sanitized)
+
+    def test_sanitize_error_message_redacts_fallback_url_credentials(self):
+        message = "proxy failed: http://user:secret@proxy.example:8080 timeout"
+
+        sanitized = download_video._sanitize_error_message(message, "http://other:pass@other.example:8080")
+
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("proxy.example:8080", sanitized)
+        self.assertIn("<redacted-proxy>", sanitized)
+
+    def test_download_video_error_does_not_print_error_to_stdout(self):
+        class FailingYoutubeDL:
+            def __init__(self, options):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                raise RuntimeError("proxy failed: http://user:p@ss@proxy.example:8080/ timeout")
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FailingYoutubeDL)):
+                with patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+                    with self.assertRaises(RuntimeError):
+                        download_video.download_video(
+                            "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                            temp_dir,
+                            proxy="http://user:p@ss@proxy.example:8080",
+                        )
+
+        self.assertNotIn("[ERROR] 下载失败", stdout.getvalue())
+        self.assertNotIn("p@ss", stdout.getvalue())
+        self.assertNotIn("p@ss", stderr.getvalue())
+
+    def test_main_download_failure_redacts_proxy_password_from_output(self):
+        class FailingYoutubeDL:
+            def __init__(self, options):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                raise RuntimeError("proxy failed: http://user:p@ss@proxy.example:8080/ timeout")
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FailingYoutubeDL)):
+                with patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+                    exit_code = download_video.main(
+                        [
+                            "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                            temp_dir,
+                            "--proxy",
+                            "http://user:p@ss@proxy.example:8080",
+                            "--env-file",
+                            str(Path(temp_dir) / "missing.env"),
+                        ]
+                    )
+
+        self.assertEqual(exit_code, 1)
+        self.assertNotIn("p@ss", stdout.getvalue())
+        self.assertNotIn("p@ss", stderr.getvalue())
+        self.assertNotIn("ss@proxy", stdout.getvalue())
+        self.assertNotIn("ss@proxy", stderr.getvalue())
+
+    def test_main_returns_error_for_conflicting_cookie_sources(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+            env_path = Path(temp_dir) / "download.env"
+            env_path.write_text("YT_DLP_PROXY=http://user:secret@proxy.example:8080\n", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("sys.stderr", stderr):
+                    exit_code = download_video.main(
+                        [
+                            "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                            "--cookies-from-browser",
+                            "firefox",
+                            "--cookies-file",
+                            str(cookie_path),
+                            "--env-file",
+                            str(env_path),
+                        ]
+                    )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("mutually exclusive", stderr.getvalue())
+        self.assertNotIn("secret", stderr.getvalue())
+
+    def test_download_video_rejects_conflicting_cookie_sources(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                download_video.download_video(
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    temp_dir,
+                    fresh_firefox_cookies=True,
+                    cookies_file=str(cookie_path),
+                )
+
+    def test_download_video_raises_sanitized_error_for_direct_call(self):
+        class FakeYoutubeDL:
+            def __init__(self, options):
+                self.options = options
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                raise RuntimeError("proxy failed: http://user:secret@proxy.example:8080 timeout")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                with self.assertRaisesRegex(RuntimeError, "<redacted-proxy>") as context:
+                    download_video.download_video(
+                        "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                        temp_dir,
+                        proxy="http://user:secret@proxy.example:8080",
+                    )
+
+        self.assertNotIn("secret", str(context.exception))
+
+    def test_download_video_defaults_to_timestamped_youtube_clips_dir(self):
+        class FakeYoutubeDL:
+            last_options = None
+
+            def __init__(self, options):
+                FakeYoutubeDL.last_options = options
+                self.output_path = Path(options["outtmpl"].replace("%(id)s", "abc123").replace("%(ext)s", "mp4"))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                if download:
+                    self.output_path.write_bytes(b"video")
+                return {"id": "abc123", "title": "Example Video", "duration": 123}
+
+            def prepare_filename(self, info):
+                return str(self.output_path)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            default_output_dir = Path(temp_dir) / "youtube-clips" / "20260510_120000"
+            with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                with patch.object(download_video, "_timestamped_output_dir", return_value=str(default_output_dir)):
+                    download_video.download_video("https://youtube.com/watch?v=Ckt1cj0xjRM")
+
+        self.assertEqual(Path(FakeYoutubeDL.last_options["outtmpl"]).parent, default_output_dir)
+
+    def test_download_video_returns_dict_contract(self):
+        class FakeYoutubeDL:
+            last_options = None
+
+            def __init__(self, options):
+                FakeYoutubeDL.last_options = options
+                self.options = options
+                self.output_path = Path(options["outtmpl"].replace("%(id)s", "abc123").replace("%(ext)s", "mp4"))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                if download:
+                    self.output_path.write_bytes(b"video")
+                    self.output_path.with_name("abc123.en.vtt").write_text("WEBVTT\n\n", encoding="utf-8")
+                return {
+                    "id": "abc123",
+                    "title": "Example Video",
+                    "duration": 123,
+                }
+
+            def prepare_filename(self, info):
+                return str(self.output_path)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                result = download_video.download_video(
+                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                    temp_dir,
+                    cookies_from_browser="firefox",
+                    proxy="http://proxy:8080",
+                    rate_limit="50K",
+                    max_video_height="2160",
+                )
+
+        self.assertEqual(set(result.keys()), {"video_path", "subtitle_path", "title", "duration", "file_size", "video_id"})
+        self.assertEqual(result["title"], "Example Video")
+        self.assertEqual(result["video_id"], "abc123")
+        self.assertEqual(FakeYoutubeDL.last_options["cookiesfrombrowser"], ("firefox",))
+        self.assertEqual(FakeYoutubeDL.last_options["proxy"], "http://proxy:8080")
+        self.assertEqual(FakeYoutubeDL.last_options["ratelimit"], "50K")
+        self.assertIn("height<=2160", FakeYoutubeDL.last_options["format"])
+
+    def test_download_video_does_not_delete_caller_supplied_cookiefile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = Path(temp_dir) / "caller-cookies.txt"
+            cookie_path.write_text("cookie-data", encoding="utf-8")
+
+            class FakeYoutubeDL:
+                def __init__(self, options):
+                    self.output_path = Path(options["outtmpl"].replace("%(id)s", "abc123").replace("%(ext)s", "mp4"))
+                    self.cookiefile = Path(options["cookiefile"])
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def extract_info(self, url, download=False):
+                    if not self.cookiefile.exists():
+                        raise AssertionError("caller cookiefile should exist during yt-dlp execution")
+                    if download:
+                        self.output_path.write_bytes(b"video")
+                        self.output_path.with_name("abc123.en.vtt").write_text("WEBVTT\n\n", encoding="utf-8")
+                    return {
+                        "id": "abc123",
+                        "title": "Example Video",
+                        "duration": 123,
+                    }
+
+                def prepare_filename(self, info):
+                    return str(self.output_path)
+
+            with patch.object(download_video, "_create_temp_cookiefile", side_effect=AssertionError("should not create temp cookiefile")):
+                with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                    result = download_video.download_video(
+                        "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                        temp_dir,
+                        fresh_firefox_cookies=True,
+                        fresh_firefox_cookiefile=str(cookie_path),
+                    )
+
+            self.assertEqual(result["video_id"], "abc123")
+            self.assertTrue(cookie_path.exists())
+
+    def test_download_video_cleans_up_temp_cookiefile_by_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_cookie_path = Path(temp_dir) / "fresh-firefox-cookies.txt"
+            temp_cookie_path.write_text("", encoding="utf-8")
+
+            class FakeYoutubeDL:
+                last_options = None
+
+                def __init__(self, options):
+                    FakeYoutubeDL.last_options = options
+                    self.output_path = Path(options["outtmpl"].replace("%(id)s", "abc123").replace("%(ext)s", "mp4"))
+                    self.cookiefile = Path(options["cookiefile"])
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def extract_info(self, url, download=False):
+                    if not self.cookiefile.exists():
+                        raise AssertionError("temp cookiefile should exist during yt-dlp execution")
+                    if download:
+                        self.output_path.write_bytes(b"video")
+                        self.output_path.with_name("abc123.en.vtt").write_text("WEBVTT\n\n", encoding="utf-8")
+                    return {
+                        "id": "abc123",
+                        "title": "Example Video",
+                        "duration": 123,
+                    }
+
+                def prepare_filename(self, info):
+                    return str(self.output_path)
+
+            with patch.object(download_video, "_create_temp_cookiefile", return_value=temp_cookie_path):
+                with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                    result = download_video.download_video(
+                        "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                        temp_dir,
+                        fresh_firefox_cookies=True,
+                    )
+
+            self.assertEqual(result["video_id"], "abc123")
+            self.assertEqual(FakeYoutubeDL.last_options["cookiesfrombrowser"], ("firefox",))
+            self.assertFalse(temp_cookie_path.exists())
+
+    def test_download_video_keeps_temp_cookiefile_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_cookie_path = Path(temp_dir) / "fresh-firefox-cookies.txt"
+            temp_cookie_path.write_text("", encoding="utf-8")
+
+            class FakeYoutubeDL:
+                last_options = None
+
+                def __init__(self, options):
+                    FakeYoutubeDL.last_options = options
+                    self.output_path = Path(options["outtmpl"].replace("%(id)s", "abc123").replace("%(ext)s", "mp4"))
+                    self.cookiefile = Path(options["cookiefile"])
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def extract_info(self, url, download=False):
+                    if not self.cookiefile.exists():
+                        raise AssertionError("temp cookiefile should exist during yt-dlp execution")
+                    if download:
+                        self.output_path.write_bytes(b"video")
+                        self.output_path.with_name("abc123.en.vtt").write_text("WEBVTT\n\n", encoding="utf-8")
+                    return {
+                        "id": "abc123",
+                        "title": "Example Video",
+                        "duration": 123,
+                    }
+
+                def prepare_filename(self, info):
+                    return str(self.output_path)
+
+            with patch.object(download_video, "_create_temp_cookiefile", return_value=temp_cookie_path):
+                with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                    with patch("builtins.print") as mock_print:
+                        result = download_video.download_video(
+                            "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                            temp_dir,
+                            fresh_firefox_cookies=True,
+                            fresh_firefox_profile="work",
+                            keep_temp_cookies=True,
+                        )
+
+            warning_output = " ".join(str(call.args[0]) for call in mock_print.call_args_list if call.args)
+            self.assertIn("保留临时 cookies 文件", warning_output)
+            self.assertTrue(temp_cookie_path.exists())
+            temp_cookie_path.unlink()
+
+        self.assertEqual(result["video_id"], "abc123")
+        self.assertEqual(FakeYoutubeDL.last_options["cookiesfrombrowser"], ("firefox", "work"))
+
+    def test_cleanup_temp_cookiefile_unlink_error_does_not_mask_download_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_cookie_path = Path(temp_dir) / "fresh-firefox-cookies.txt"
+            temp_cookie_path.write_text("", encoding="utf-8")
+            stderr = io.StringIO()
+
+            class FakeYoutubeDL:
+                def __init__(self, options):
+                    self.cookiefile = Path(options["cookiefile"])
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def extract_info(self, url, download=False):
+                    if not self.cookiefile.exists():
+                        raise AssertionError("temp cookiefile should exist during yt-dlp execution")
+                    raise RuntimeError("boom")
+
+            with patch.object(download_video, "_create_temp_cookiefile", return_value=temp_cookie_path):
+                with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                    with patch.object(Path, "unlink", side_effect=PermissionError("access denied")):
+                        with patch("sys.stderr", stderr):
+                            with self.assertRaisesRegex(RuntimeError, "boom"):
+                                download_video.download_video(
+                                    "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                                    temp_dir,
+                                    fresh_firefox_cookies=True,
+                                )
+
+            self.assertIn("清理临时 cookies 文件失败", stderr.getvalue())
+
+    def test_download_video_cleans_up_temp_cookiefile_when_download_fails(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_cookie_path = Path(temp_dir) / "fresh-firefox-cookies.txt"
+            temp_cookie_path.write_text("", encoding="utf-8")
+
+            class FakeYoutubeDL:
+                def __init__(self, options):
+                    self.cookiefile = Path(options["cookiefile"])
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def extract_info(self, url, download=False):
+                    if not self.cookiefile.exists():
+                        raise AssertionError("temp cookiefile should exist during yt-dlp execution")
+                    raise RuntimeError("boom")
+
+            with patch.object(download_video, "_create_temp_cookiefile", return_value=temp_cookie_path):
+                with patch.object(download_video, "yt_dlp", SimpleNamespace(YoutubeDL=FakeYoutubeDL)):
+                    with self.assertRaisesRegex(RuntimeError, "boom"):
+                        download_video.download_video(
+                            "https://youtube.com/watch?v=Ckt1cj0xjRM",
+                            temp_dir,
+                            fresh_firefox_cookies=True,
+                        )
+
+            self.assertFalse(temp_cookie_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR lands fresh Firefox cookie export onto main. It adds explicit fresh Firefox cookie flags and env support, creates temporary cookie files only during download, cleans them up automatically unless explicitly preserved, expands user output paths safely, and avoids logging cookie/proxy secrets.